### PR TITLE
Bug/cache expiration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# VS Code IDE files
+.vscode/
+
 # Runtime data
 pids
 *.pid

--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 # Arc
-[![Build Status](https://travis-ci.org/altereagle/arc.svg?branch=master)](https://travis-ci.org/altereagle/arc)
-[![Maintainability](https://api.codeclimate.com/v1/badges/250cba5c85e88cec6dfb/maintainability)](https://codeclimate.com/github/altereagle/arc/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/250cba5c85e88cec6dfb/test_coverage)](https://codeclimate.com/github/altereagle/arc/test_coverage)
+[![Build Status](https://travis-ci.com/elevatorup/arc.svg?branch=maste#)](https://travis-ci.com/elevatorup/arc)
 
-A Node Development Microservice Framework
-
-![gif](https://media.giphy.com/media/kFyLfPH7FU7zW/giphy.gif)
+A Node Development Microservice Framework 
 
 ### Install
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcms",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "A Node Development Microservice Framework",
   "main": "index.js",
   "scripts": {

--- a/support/process/index.js
+++ b/support/process/index.js
@@ -119,7 +119,7 @@ const endJob = (result, error) => {
 };
 
 // This process can get or set cached data
-process.cache = (key, value) => {
+process.cache = (key, value, ...rest) => {
   return new Promise((resolve, reject) => {
     // Arc checks if the key and the value exist
     const keyExists = (typeof key === `string`);
@@ -134,7 +134,7 @@ process.cache = (key, value) => {
 
     // Arc caches the data using `Paperboy` if the cache method is used for saving data
     if(setData) {
-      return paperboy.push(cacheKey, value)
+      return paperboy.push(cacheKey, value, rest[0], rest[1])
         .then(() => {
           resolve(value);
         })


### PR DESCRIPTION
Arc uses [Paperboy](https://github.com/altereagle/paperboy) to wrap the mechanics of key-value storage and pub/sub flows implemented in Redis. The Paperboy [`push` method](https://github.com/altereagle/paperboy/blob/6967239df744e9d320035c3aee5bf027943efaee/index.js#L172), which corresponds the the Redis [`SET` command](https://redis.io/commands/set), accepts extra arguments (`args`, `details`) that correspond to the options allowed in the `SET` command, including `EX [seconds]`, `PX [milliseconds]`, `NX`, and `XX`. The most common use case is using the `EX` or `PX` options to set a key's expiration in the same operation as setting its value.

In the [`process` module](https://github.com/altereagle/arc/blob/master/support/process/index.js), Arc wraps calls to either `Paperboy.push` or `Paperboy.pull` with an anonymous function assigned to `process.cache`:

https://github.com/altereagle/arc/blob/013889fbd6fba9e695962a356c7f5521e14b479c/support/process/index.js#L122-L126

In its current form, this function does not pass any extra arguments through to `Paperboy.push`, so it's not possible to set the expiration of a key via `process.cache()`. 

This change allows optional extra arguments and passes the first two (if they exist) through to Paperboy.push, which in turn allows workers using the `process.cache()` method to set expirations using the following syntax:

```js
// Set a key and its expiration to 300 seconds from now
process.cache('some key', 'a value', 'EX', 300);
```

Note the `arguments` array is [not available inside an arrow function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#No_binding_of_arguments), so I explicitly add a [rest parameter array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) to accommodate the optional extra arguments needed here.